### PR TITLE
Feature/1.12.2 test

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,3 +3,5 @@ Ringu is a mod for providing rings for adding buffs to the player.
 Currently only "The One Ring" is available with configurable buffs, including Flight, Speed buffs, a food source, an item magnet, effects and cures.
 
 When activated with Sneak right click the ring imparts the buffs on the player. Once buffed the ring becomes deplated and cannot buff other players. The buffs persist through death but can be removed by Sneak right clicking on a depleated ring.
+
+TEST

--- a/README.md
+++ b/README.md
@@ -1,7 +1,5 @@
 Ringu is a mod for providing rings for adding buffs to the player.
 
-Currently only "The One Ring" is available with configurable buffs, including Flight, Speed buffs, a food source, an item magnet, effects and cures.
+Currently, only "The One Ring" is available with configurable buffs, including Flight, Speed buffs, a food source, an item magnet, effects and cures.
 
-When activated with Sneak right click the ring imparts the buffs on the player. Once buffed the ring becomes deplated and cannot buff other players. The buffs persist through death but can be removed by Sneak right clicking on a depleated ring.
-
-TEST
+When activated with Sneak right click the ring imparts the buffs on the player. Once buffed the ring becomes depleted and cannot buff other players. The buffs persist through death but can be removed by Sneak right clicking on a depleted ring or the base ring.

--- a/src/main/java/com/verch/ringu/Ringu.java
+++ b/src/main/java/com/verch/ringu/Ringu.java
@@ -11,38 +11,43 @@ import net.minecraftforge.fml.common.event.FMLPostInitializationEvent;
 import net.minecraftforge.fml.common.event.FMLPreInitializationEvent;
 import org.apache.logging.log4j.Logger;
 
-@Mod(modid = Ringu.MODID, name = Ringu.NAME, version = Ringu.VERSION, dependencies = "required-after:forge@[" + Ringu.MIN_FORGE_VER + ",)", useMetadata = true)
+@Mod(
+    modid = Ringu.MODID,
+    name = Ringu.NAME,
+    version = Ringu.VERSION,
+    dependencies = "required-after:forge@[" + Ringu.MIN_FORGE_VER + ",)",
+    useMetadata = true)
 public class Ringu {
-    public static final String MODID = "ringu";
-    static final String NAME = "Ringu";
-    static final String VERSION = "1.12.2-1.3.0";
-    static final String MIN_FORGE_VER = "14.23.5.2768";
+  public static final String MODID = "ringu";
+  static final String NAME = "Ringu";
+  static final String VERSION = "1.12.2-1.3.0";
+  static final String MIN_FORGE_VER = "14.23.5.2768";
 
-    public static Logger logger;
+  public static Logger logger;
 
-    @SidedProxy(clientSide = "com.verch.ringu.proxy.ClientProxy", serverSide = "com.verch.ringu.proxy.ServerProxy")
-    public static CommonProxy proxy;
+  @SidedProxy(
+      clientSide = "com.verch.ringu.proxy.ClientProxy",
+      serverSide = "com.verch.ringu.proxy.ServerProxy")
+  public static CommonProxy proxy;
 
-    public static CreativeTabs creativeTab = new RinguCreativeTab(NAME);
+  public static CreativeTabs creativeTab = new RinguCreativeTab(NAME);
 
-    @Mod.Instance
-    public static Ringu instance;
+  @Mod.Instance public static Ringu instance;
 
-    @Mod.EventHandler
-    public void preInit(FMLPreInitializationEvent event) {
-        logger = event.getModLog();
-        proxy.preInit(event);
-    }
+  @Mod.EventHandler
+  public void preInit(FMLPreInitializationEvent event) {
+    logger = event.getModLog();
+    proxy.preInit(event);
+  }
 
-    @Mod.EventHandler
-    public void init(FMLInitializationEvent event) {
-        proxy.init(event);
-    }
+  @Mod.EventHandler
+  public void init(FMLInitializationEvent event) {
+    proxy.init(event);
+  }
 
-    @Mod.EventHandler
-    public void postInit(FMLPostInitializationEvent event) {
-        RinguConfig.postInit();
-        proxy.postInit(event);
-    }
-
+  @Mod.EventHandler
+  public void postInit(FMLPostInitializationEvent event) {
+    RinguConfig.postInit();
+    proxy.postInit(event);
+  }
 }

--- a/src/main/java/com/verch/ringu/RinguItems.java
+++ b/src/main/java/com/verch/ringu/RinguItems.java
@@ -7,18 +7,18 @@ import net.minecraftforge.fml.relauncher.SideOnly;
 
 public class RinguItems {
 
-    public static ItemBaseRing itemBaseRing;
-    public static ItemOneRing itemOneRing;
+  public static ItemBaseRing itemBaseRing;
+  public static ItemOneRing itemOneRing;
 
-    @SideOnly(Side.CLIENT)
-    public static void init() {
-        itemBaseRing = new ItemBaseRing();
-        itemOneRing = new ItemOneRing();
-    }
+  @SideOnly(Side.CLIENT)
+  public static void init() {
+    itemBaseRing = new ItemBaseRing();
+    itemOneRing = new ItemOneRing();
+  }
 
-    @SideOnly(Side.CLIENT)
-    public static void initModels() {
-        itemBaseRing.initModel();
-        itemOneRing.initModel();
-    }
+  @SideOnly(Side.CLIENT)
+  public static void initModels() {
+    itemBaseRing.initModel();
+    itemOneRing.initModel();
+  }
 }

--- a/src/main/java/com/verch/ringu/buff/Buff.java
+++ b/src/main/java/com/verch/ringu/buff/Buff.java
@@ -2,6 +2,7 @@ package com.verch.ringu.buff;
 
 import com.verch.ringu.effect.BuffEffect;
 import com.verch.ringu.setup.RinguConfig;
+import java.util.List;
 import net.minecraft.entity.Entity;
 import net.minecraft.entity.item.EntityItem;
 import net.minecraft.entity.item.EntityXPOrb;
@@ -11,145 +12,160 @@ import net.minecraft.potion.PotionEffect;
 import net.minecraft.util.math.AxisAlignedBB;
 import net.minecraft.world.World;
 
-import java.util.List;
-
 public class Buff {
 
-    private static final float defaultWalkSpeed = 0.1f;
-    private static final float defaultFlySpeed = 0.05f;
-    private static final int airFull = 300;
+  private static final float defaultWalkSpeed = 0.1f;
+  private static final float defaultFlySpeed = 0.05f;
+  private static final int airFull = 300;
 
-    private static final boolean enableFlight = RinguConfig.flight.enableFlight;
-    private static final float buffFlySpeed = RinguConfig.flight.flySpeedMultiplier * defaultFlySpeed;
+  private static final boolean enableFlight = RinguConfig.flight.enableFlight;
+  private static final float buffFlySpeed = RinguConfig.flight.flySpeedMultiplier * defaultFlySpeed;
 
-    private static final boolean enableWalkingBuff = RinguConfig.ground.enableWalkingBuff;
-    private static final float buffWalkSpeed = RinguConfig.ground.walkSpeedMultiplier * defaultWalkSpeed;
+  private static final boolean enableWalkingBuff = RinguConfig.ground.enableWalkingBuff;
+  private static final float buffWalkSpeed =
+      RinguConfig.ground.walkSpeedMultiplier * defaultWalkSpeed;
 
-    private static final boolean enableWaterBreathing = RinguConfig.water.enableWaterBreathing;
+  private static final boolean enableWaterBreathing = RinguConfig.water.enableWaterBreathing;
 
-    private static final boolean enableFood = RinguConfig.food.enableFood;
-    private static final int foodToAdd = RinguConfig.food.foodToAdd;
-    private static final float foodSaturationToAdd = RinguConfig.food.foodSaturationToAdd;
+  private static final boolean enableFood = RinguConfig.food.enableFood;
+  private static final int foodToAdd = RinguConfig.food.foodToAdd;
+  private static final float foodSaturationToAdd = RinguConfig.food.foodSaturationToAdd;
 
-    private static final boolean enableEffect = RinguConfig.effect.enableEffect;
-    private static final BuffEffect[] buffEffectArray = RinguConfig.effect.buffEffectArray;
+  private static final boolean enableEffect = RinguConfig.effect.enableEffect;
+  private static final BuffEffect[] buffEffectArray = RinguConfig.effect.buffEffectArray;
 
-    private static final boolean enableCure = RinguConfig.cure.enableCure;
-    private static final Potion[] cureEffectArray = RinguConfig.cure.cureEffectArray;
+  private static final boolean enableCure = RinguConfig.cure.enableCure;
+  private static final Potion[] cureEffectArray = RinguConfig.cure.cureEffectArray;
 
-    private static final boolean enableMagnet = RinguConfig.magnet.enableMagnet;
-    private static final int magnetRange = RinguConfig.magnet.magnetRange;
+  private static final boolean enableMagnet = RinguConfig.magnet.enableMagnet;
+  private static final int magnetRange = RinguConfig.magnet.magnetRange;
 
-    private static boolean isDelayed(Entity entity) {
-        if (entity instanceof EntityItem) {
-            return ((EntityItem) entity).cannotPickup();
-        } else if (entity instanceof EntityXPOrb) return ((EntityXPOrb) entity).delayBeforeCanPickup > 0;
-        else {
-            return true;
-        }
+  private static boolean isDelayed(Entity entity) {
+    if (entity instanceof EntityItem) {
+      return ((EntityItem) entity).cannotPickup();
+    } else if (entity instanceof EntityXPOrb)
+      return ((EntityXPOrb) entity).delayBeforeCanPickup > 0;
+    else {
+      return true;
+    }
+  }
+
+  private static void moveEntityToPlayer(EntityPlayer player, Entity entity) {
+    entity.motionX = entity.motionY = entity.motionZ = 0;
+    entity.setPosition(
+        player.posX - 0.2 + (player.world.rand.nextDouble() * 0.4),
+        player.posY - 0.6,
+        player.posZ - 0.2 + (player.world.rand.nextDouble() * 0.4));
+  }
+
+  private static boolean canMoveEntity(EntityPlayer player, Entity entity) {
+    if (entity.getEntityData().getBoolean("PreventRemoteMovement") || entity.isDead) {
+      return false;
     }
 
-    private static void moveEntityToPlayer(EntityPlayer player, Entity entity) {
-        entity.motionX = entity.motionY = entity.motionZ = 0;
-        entity.setPosition(player.posX - 0.2 + (player.world.rand.nextDouble() * 0.4), player.posY - 0.6, player.posZ - 0.2 + (player.world.rand.nextDouble() * 0.4));
+    EntityPlayer closest = player.world.getClosestPlayerToEntity(entity, 4);
+    if (closest != null && closest != player) {
+      return false;
     }
 
-    private static boolean canMoveEntity(EntityPlayer player, Entity entity) {
-        if (entity.getEntityData().getBoolean("PreventRemoteMovement") || entity.isDead) {
-            return false;
-        }
+    return !isDelayed(entity);
+  }
 
-        EntityPlayer closest = player.world.getClosestPlayerToEntity(entity, 4);
-        if (closest != null && closest != player) {
-            return false;
-        }
-
-        if (isDelayed(entity)) {
-            return false;
-        }
-        return true;
+  private static void updateMagnet(EntityPlayer player) {
+    if (!enableMagnet || player.isSneaking()) {
+      return;
     }
 
+    World world = player.world;
 
-    private static void updateMagnet(EntityPlayer player) {
-        if (!enableMagnet || player.isSneaking()) {
-            return;
-        }
+    List<EntityItem> items =
+        world.getEntitiesWithinAABB(
+            EntityItem.class,
+            new AxisAlignedBB(
+                    player.posX, player.posY, player.posZ, player.posX, player.posY, player.posZ)
+                .grow(magnetRange, magnetRange, magnetRange));
 
-        World world = player.world;
-
-        List<EntityItem> items = world.getEntitiesWithinAABB(EntityItem.class, new AxisAlignedBB(player.posX, player.posY, player.posZ, player.posX, player.posY, player.posZ).grow(magnetRange, magnetRange, magnetRange));
-
-        for (Entity entity : items) {
-            if (canMoveEntity(player, entity)) {
-                moveEntityToPlayer(player, entity);
-            }
-        }
-
-        List<EntityXPOrb> xp = world.getEntitiesWithinAABB(EntityXPOrb.class, new AxisAlignedBB(player.posX, player.posY, player.posZ, player.posX, player.posY, player.posZ).grow(magnetRange, magnetRange, magnetRange));
-
-        for (EntityXPOrb orb : xp) {
-            if (canMoveEntity(player, (Entity) orb)) {
-                player.onItemPickup(orb, 1);
-                player.addExperience(orb.xpValue);
-                orb.setDead();
-            }
-        }
+    for (Entity entity : items) {
+      if (canMoveEntity(player, entity)) {
+        moveEntityToPlayer(player, entity);
+      }
     }
 
-    private static void passiveBuff(EntityPlayer player) {
-        if (enableFood) {
-            player.getFoodStats().addStats(foodToAdd, foodSaturationToAdd);
-        }
-        if (enableWaterBreathing) {
-            player.setAir(airFull);
-        }
-        if (enableEffect) {
-            for (BuffEffect buffEffect : buffEffectArray) {
-                player.addPotionEffect(new PotionEffect(buffEffect.getEffect(), buffEffect.getDuration(), buffEffect.getLevel(), true, false));
-            }
-        }
-        if (enableCure) {
-            for (Potion cureEffect : cureEffectArray) {
-                player.removePotionEffect(cureEffect);
-            }
-        }
+    List<EntityXPOrb> xp =
+        world.getEntitiesWithinAABB(
+            EntityXPOrb.class,
+            new AxisAlignedBB(
+                    player.posX, player.posY, player.posZ, player.posX, player.posY, player.posZ)
+                .grow(magnetRange, magnetRange, magnetRange));
+
+    for (EntityXPOrb orb : xp) {
+      if (canMoveEntity(player, orb)) {
+        player.onItemPickup(orb, 1);
+        player.addExperience(orb.xpValue);
+        orb.setDead();
+      }
+    }
+  }
+
+  private static void passiveBuff(EntityPlayer player) {
+    if (enableFood) {
+      player.getFoodStats().addStats(foodToAdd, foodSaturationToAdd);
+    }
+    if (enableWaterBreathing) {
+      player.setAir(airFull);
+    }
+    if (enableEffect) {
+      for (BuffEffect buffEffect : buffEffectArray) {
+        player.addPotionEffect(
+            new PotionEffect(
+                buffEffect.getEffect(),
+                buffEffect.getDuration(),
+                buffEffect.getLevel(),
+                true,
+                false));
+      }
+    }
+    if (enableCure) {
+      for (Potion cureEffect : cureEffectArray) {
+        player.removePotionEffect(cureEffect);
+      }
+    }
+  }
+
+  public static void onTickActive(EntityPlayer player) {
+    if (enableMagnet) {
+      updateMagnet(player);
+    }
+  }
+
+  public static void onTickPassive(EntityPlayer player) {
+    passiveBuff(player);
+  }
+
+  public static void onActivation(EntityPlayer player) {
+    if (enableFlight) {
+      player.capabilities.allowFlying = true;
+      player.capabilities.setFlySpeed(buffFlySpeed);
+    }
+    if (enableWalkingBuff) {
+      player.capabilities.setPlayerWalkSpeed(buffWalkSpeed);
     }
 
-    public static void onTickActive(EntityPlayer player) {
-        if (enableMagnet) {
-            updateMagnet(player);
-        }
+    player.sendPlayerAbilities();
+  }
+
+  public static void onDeactivation(EntityPlayer player) {
+    if (enableFlight) {
+      player.capabilities.setFlySpeed(defaultFlySpeed);
+      if (!player.isCreative()) {
+        player.capabilities.isFlying = false;
+        player.capabilities.allowFlying = false;
+      }
+    }
+    if (enableWalkingBuff) {
+      player.capabilities.setPlayerWalkSpeed(defaultWalkSpeed);
     }
 
-    public static void onTickPassive(EntityPlayer player) {
-        passiveBuff(player);
-    }
-
-    public static void onActivation(EntityPlayer player) {
-        if (enableFlight) {
-            player.capabilities.allowFlying = true;
-            player.capabilities.setFlySpeed(buffFlySpeed);
-        }
-        if (enableWalkingBuff) {
-            player.capabilities.setPlayerWalkSpeed(buffWalkSpeed);
-        }
-
-        player.sendPlayerAbilities();
-    }
-
-    public static void onDeactivation(EntityPlayer player) {
-        if (enableFlight) {
-            player.capabilities.setFlySpeed(defaultFlySpeed);
-            if (!player.isCreative()) {
-                player.capabilities.isFlying = false;
-                player.capabilities.allowFlying = false;
-            }
-        }
-        if (enableWalkingBuff) {
-            player.capabilities.setPlayerWalkSpeed(defaultWalkSpeed);
-        }
-
-        player.sendPlayerAbilities();
-    }
+    player.sendPlayerAbilities();
+  }
 }

--- a/src/main/java/com/verch/ringu/effect/BuffEffect.java
+++ b/src/main/java/com/verch/ringu/effect/BuffEffect.java
@@ -5,77 +5,81 @@ import net.minecraft.potion.Potion;
 
 public class BuffEffect {
 
-    private static String fieldSeparator = ",";
+  private static String fieldSeparator = ",";
 
-    private Potion effect;
-    private int level;
-    private int duration;
+  private Potion effect;
+  private int level;
+  private int duration;
 
-    public BuffEffect(Potion effect, int level, int duration) {
-        this.effect = effect;
-        this.level = level;
-        this.duration = duration;
+  public BuffEffect(Potion effect, int level, int duration) {
+    this.effect = effect;
+    this.level = level;
+    this.duration = duration;
+  }
+
+  public Potion getEffect() {
+    return this.effect;
+  }
+
+  public int getLevel() {
+    return this.level;
+  }
+
+  public int getDuration() {
+    return this.duration;
+  }
+
+  public static BuffEffect buffEffectFromName(String effectName, int level, int duration) {
+    BuffEffect buffEffect = null;
+    Potion effect = EffectUtil.effectFromName(effectName);
+    if (effect == null) {
+      return buffEffect;
+    }
+    buffEffect = new BuffEffect(effect, level, duration);
+    return buffEffect;
+  }
+
+  public static BuffEffect buffEffectFromString(String effectString) {
+    BuffEffect buffEffect = null;
+    if (effectString == null || effectString.equals("")) {
+      return buffEffect;
+    }
+    String[] fieldArray = effectString.split(fieldSeparator);
+    try {
+      buffEffect =
+          buffEffectFromName(
+              fieldArray[0], Integer.parseInt(fieldArray[1]), Integer.parseInt(fieldArray[2]));
+    } catch (Exception e) {
+      Ringu.logger.error("Cannot parse configuration effect: " + effectString);
     }
 
-    public Potion getEffect() {
-        return this.effect;
+    return buffEffect;
+  }
+
+  public static BuffEffect[] BuffEffectListFromEffectStringArray(String[] effectStringArray) {
+    BuffEffect[] buffEffectArray = new BuffEffect[effectStringArray.length];
+    for (int i = 0; i < effectStringArray.length; i++) {
+      buffEffectArray[i] = buffEffectFromString(effectStringArray[i]);
     }
 
-    public int getLevel() {
-        return this.level;
+    return buffEffectArray;
+  }
+
+  public static String buffEffectToEffectString(BuffEffect buffEffect) {
+    return buffEffect.getEffect().getRegistryName()
+        + fieldSeparator
+        + buffEffect.getLevel()
+        + fieldSeparator
+        + buffEffect.getDuration();
+  }
+
+  public static String[] buffEffectArrayToEffectStringArray(BuffEffect[] buffEffectArray) {
+    String[] effectStringArray = new String[buffEffectArray.length];
+
+    for (int i = 0; i < buffEffectArray.length; i++) {
+      effectStringArray[i] = buffEffectToEffectString(buffEffectArray[i]);
     }
 
-    public int getDuration() {
-        return this.duration;
-    }
-
-    public static BuffEffect buffEffectFromName(String effectName, int level, int duration) {
-        BuffEffect buffEffect = null;
-        Potion effect = EffectUtil.effectFromName(effectName);
-        if (effect == null) {
-            return buffEffect;
-        }
-        buffEffect = new BuffEffect(effect, level, duration);
-        return buffEffect;
-    }
-
-    public static BuffEffect buffEffectFromString(String effectString) {
-        BuffEffect buffEffect = null;
-        if (effectString == null || effectString.equals("")) {
-            return buffEffect;
-        }
-        String[] fieldArray = effectString.split(fieldSeparator);
-        try {
-            buffEffect = buffEffectFromName(fieldArray[0], Integer.parseInt(fieldArray[1]), Integer.parseInt(fieldArray[2]));
-        } catch (Exception e) {
-            Ringu.logger.error("Cannot parse configuration effect: " + effectString);
-        }
-
-        return buffEffect;
-    }
-
-    public static BuffEffect[] BuffEffectListFromEffectStringArray(String[] effectStringArray) {
-        BuffEffect[] buffEffectArray = new BuffEffect[effectStringArray.length];
-        for (int i = 0; i < effectStringArray.length; i++) {
-            buffEffectArray[i] = buffEffectFromString(effectStringArray[i]);
-        }
-
-        return buffEffectArray;
-    }
-
-    public static String buffEffectToEffectString(BuffEffect buffEffect) {
-        return buffEffect.getEffect().getRegistryName() + fieldSeparator + buffEffect.getLevel() + fieldSeparator + buffEffect.getDuration();
-    }
-
-    public static String[] buffEffectArrayToEffectStringArray(BuffEffect[] buffEffectArray) {
-        String[] effectStringArray = new String[buffEffectArray.length];
-
-        for (int i = 0; i < buffEffectArray.length; i++) {
-            effectStringArray[i] = buffEffectToEffectString(buffEffectArray[i]);
-        }
-
-        return effectStringArray;
-    }
-
-
+    return effectStringArray;
+  }
 }

--- a/src/main/java/com/verch/ringu/effect/EffectUtil.java
+++ b/src/main/java/com/verch/ringu/effect/EffectUtil.java
@@ -5,41 +5,40 @@ import net.minecraft.potion.Potion;
 
 public class EffectUtil {
 
-    static Potion effectFromName(String effectName) {
-        Potion effect = null;
-        if (effectName == null || effectName.equals("")) {
-            return effect;
-        }
-        try {
-            effect = Potion.getPotionFromResourceLocation(effectName.trim());
+  static Potion effectFromName(String effectName) {
+    Potion effect = null;
+    if (effectName == null || effectName.equals("")) {
+      return effect;
+    }
+    try {
+      effect = Potion.getPotionFromResourceLocation(effectName.trim());
 
-            if (effect == null) {
-                throw new IllegalArgumentException("Effect not found");
-            }
-        } catch (Exception e) {
-            Ringu.logger.error("Cannot find effect with name " + effectName);
-        }
-        return effect;
+      if (effect == null) {
+        throw new IllegalArgumentException("Effect not found");
+      }
+    } catch (Exception e) {
+      Ringu.logger.error("Cannot find effect with name " + effectName);
+    }
+    return effect;
+  }
+
+  public static Potion[] effectArrayFromEffectStringArray(String[] effectStringArray) {
+    Potion[] effectArray = new Potion[effectStringArray.length];
+
+    for (int i = 0; i < effectStringArray.length; i++) {
+      effectArray[i] = effectFromName(effectStringArray[i]);
     }
 
-    public static Potion[] effectArrayFromEffectStringArray(String[] effectStringArray) {
-        Potion[] effectArray = new Potion[effectStringArray.length];
+    return effectArray;
+  }
 
-        for (int i = 0; i < effectStringArray.length; i++) {
-            effectArray[i] = effectFromName(effectStringArray[i]);
-        }
+  public static String[] effectArrayToEffectStringArray(Potion[] effectList) {
+    String[] effectStringArray = new String[effectList.length];
 
-        return effectArray;
+    for (int i = 0; i < effectList.length; i++) {
+      effectStringArray[i] = effectList[i].getRegistryName().toString();
     }
 
-    public static String[] effectArrayToEffectStringArray(Potion[] effectList) {
-        String[] effectStringArray = new String[effectList.length];
-
-        for (int i = 0; i < effectList.length; i++) {
-            effectStringArray[i] = effectList[i].getRegistryName().toString();
-        }
-
-        return effectStringArray;
-    }
-
+    return effectStringArray;
+  }
 }

--- a/src/main/java/com/verch/ringu/event/RinguEvent.java
+++ b/src/main/java/com/verch/ringu/event/RinguEvent.java
@@ -1,8 +1,9 @@
 package com.verch.ringu.event;
 
 import com.verch.ringu.buff.Buff;
-import com.verch.ringu.items.ItemOneRing;
+import com.verch.ringu.util.RinguNBTUtil;
 import net.minecraft.entity.player.EntityPlayer;
+import net.minecraft.item.ItemStack;
 import net.minecraftforge.fml.common.Mod;
 import net.minecraftforge.fml.common.eventhandler.SubscribeEvent;
 import net.minecraftforge.fml.common.gameevent.TickEvent;
@@ -10,46 +11,91 @@ import net.minecraftforge.fml.common.gameevent.TickEvent;
 @Mod.EventBusSubscriber
 public class RinguEvent {
 
-    private static final int maxTick = 19; //Updates every 20 ticks, i.e. every second
-    private static final int startTick = -1;
+  private static final String isActive = "ringu:onering:IsActive";
 
-    static int tick = startTick;
+  private static final int maxTick = 19; // Updates every 20 ticks, i.e. every second
+  private static final int startTick = -1;
 
-    private static int newTick(int tick) {
-        int newTick = tick + 1;
-        if (newTick >= maxTick) {
-            newTick = startTick;
-        }
+  private static int tick = startTick;
 
-        return newTick;
+  private static int newTick(int tick) {
+    int newTick = tick + 1;
+    if (newTick >= maxTick) {
+      newTick = startTick;
     }
 
-    private static boolean doUpdate(EntityPlayer player, int tick) {
-        return !player.world.isRemote && tick == 0;
+    return newTick;
+  }
+  private static boolean doUpdate(EntityPlayer player, int tick) {
+    return !player.world.isRemote && tick == 0;
+  }
+
+  public static boolean isActive(ItemStack stack) {
+    return RinguNBTUtil.getBoolean(stack, isActive, true);
+  }
+
+  private static boolean isActive(EntityPlayer player) {
+    return RinguNBTUtil.getBoolean(player, isActive, false);
+  }
+
+  private static void toggleNBTEnabled(EntityPlayer player) {
+    RinguNBTUtil.toggleBoolean(player, isActive, false);
+  }
+
+  private static void toggleNBTEnabled(ItemStack ring) {
+    RinguNBTUtil.toggleBoolean(ring, isActive, true);
+  }
+
+  public static void onActivation(EntityPlayer player) {
+    Buff.onActivation(player);
+  }
+
+  public static void onDeactivation(EntityPlayer player) {
+    Buff.onDeactivation(player);
+  }
+
+  public static void toggleEnabled(EntityPlayer player, ItemStack stack) {
+    boolean playerIsActive = isActive(player);
+    boolean itemIsActive = isActive(stack);
+
+    if (itemIsActive) {
+      RinguEvent.onActivation(player);
+    } else if (playerIsActive) {
+      RinguEvent.onDeactivation(player);
     }
 
-    public static void onActivation(EntityPlayer player){
-        Buff.onActivation(player);
+    // Only need to toggle if they have different activation states
+    if (playerIsActive != itemIsActive) {
+      toggleNBTEnabled(player);
+      toggleNBTEnabled(stack);
+    }
+  }
+
+  public static void disable(EntityPlayer player) {
+    boolean playerIsActive = isActive(player);
+    if (!playerIsActive) {
+      return;
+    }
+    onDeactivation(player);
+    toggleNBTEnabled(player);
+  }
+
+  @SubscribeEvent
+  public static void onTickServerEvent(TickEvent.ServerTickEvent event) {
+    tick = newTick(tick);
+  }
+
+  @SubscribeEvent
+  public static void onTickPlayerEvent(TickEvent.PlayerTickEvent event) {
+    EntityPlayer player = event.player;
+
+    if (!doUpdate(player, tick)) {
+      return;
     }
 
-    public static void onDeactivation(EntityPlayer player){
-        Buff.onDeactivation(player);
+    if (isActive(player)) {
+      Buff.onTickPassive(player);
+      Buff.onTickActive(player);
     }
-
-    @SubscribeEvent
-    public static void onTickServerEvent(TickEvent.ServerTickEvent event) {
-        tick = newTick(tick);
-    }
-
-    @SubscribeEvent
-    public static void onTickPlayerEvent(TickEvent.PlayerTickEvent event) {
-        EntityPlayer player = event.player;
-
-        if (!doUpdate(player, tick)){return;}
-
-        if(ItemOneRing.oneRingPlayerIsActive(player)){
-            Buff.onTickPassive(player);
-            Buff.onTickActive(player);
-        }
-    }
+  }
 }

--- a/src/main/java/com/verch/ringu/items/ItemBaseRing.java
+++ b/src/main/java/com/verch/ringu/items/ItemBaseRing.java
@@ -1,23 +1,48 @@
 package com.verch.ringu.items;
 
 import com.verch.ringu.Ringu;
+import com.verch.ringu.event.RinguEvent;
+import java.util.List;
 import net.minecraft.client.renderer.block.model.ModelResourceLocation;
+import net.minecraft.client.resources.I18n;
+import net.minecraft.client.util.ITooltipFlag;
+import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.item.Item;
+import net.minecraft.item.ItemStack;
+import net.minecraft.util.ActionResult;
+import net.minecraft.util.EnumHand;
 import net.minecraft.util.ResourceLocation;
+import net.minecraft.util.text.TextFormatting;
+import net.minecraft.world.World;
 import net.minecraftforge.client.model.ModelLoader;
 import net.minecraftforge.fml.relauncher.Side;
 import net.minecraftforge.fml.relauncher.SideOnly;
 
 public class ItemBaseRing extends Item {
 
-    public ItemBaseRing() {
-        setRegistryName(new ResourceLocation(Ringu.MODID, "basering"));
-        setUnlocalizedName(Ringu.MODID + ".basering");
-        setCreativeTab(Ringu.creativeTab);
-    }
+  public ItemBaseRing() {
+    setRegistryName(new ResourceLocation(Ringu.MODID, "basering"));
+    setUnlocalizedName(Ringu.MODID + ".basering");
+    setCreativeTab(Ringu.creativeTab);
+  }
 
-    @SideOnly(Side.CLIENT)
-    public void initModel() {
-        ModelLoader.setCustomModelResourceLocation(this, 0, new ModelResourceLocation(getRegistryName(), "inventory"));
+  @SideOnly(Side.CLIENT)
+  public void initModel() {
+    ModelLoader.setCustomModelResourceLocation(
+        this, 0, new ModelResourceLocation(getRegistryName(), "inventory"));
+  }
+
+  @Override
+  public ActionResult<ItemStack> onItemRightClick(World world, EntityPlayer player, EnumHand hand) {
+    if (!world.isRemote && player.isSneaking()) {
+      RinguEvent.disable(player);
     }
+    return super.onItemRightClick(world, player, hand);
+  }
+
+  @Override
+  public void addInformation(
+      ItemStack stack, World worldIn, List<String> tooltip, ITooltipFlag flagIn) {
+    tooltip.add(TextFormatting.BLUE + I18n.format("item.ringu.deactivate"));
+  }
 }

--- a/src/main/java/com/verch/ringu/items/ItemOneRing.java
+++ b/src/main/java/com/verch/ringu/items/ItemOneRing.java
@@ -2,7 +2,7 @@ package com.verch.ringu.items;
 
 import com.verch.ringu.Ringu;
 import com.verch.ringu.event.RinguEvent;
-import com.verch.ringu.util.RinguNBTUtil;
+import java.util.List;
 import net.minecraft.client.renderer.block.model.ModelResourceLocation;
 import net.minecraft.client.resources.I18n;
 import net.minecraft.client.util.ITooltipFlag;
@@ -17,68 +17,45 @@ import net.minecraft.world.World;
 import net.minecraftforge.client.model.ModelLoader;
 import net.minecraftforge.fml.relauncher.Side;
 import net.minecraftforge.fml.relauncher.SideOnly;
-import java.util.List;
 
 public class ItemOneRing extends Item {
 
-    private static final String isActive = "ringu:onering:IsActive";
+  public ItemOneRing() {
+    setRegistryName(new ResourceLocation(Ringu.MODID, "onering"));
+    setUnlocalizedName(Ringu.MODID + ".onering");
+    setCreativeTab(Ringu.creativeTab);
+    this.setMaxStackSize(1);
+  }
 
-    public ItemOneRing() {
-        setRegistryName(new ResourceLocation(Ringu.MODID, "onering"));
-        setUnlocalizedName(Ringu.MODID + ".onering");
-        setCreativeTab(Ringu.creativeTab);
-        this.setMaxStackSize(1);
+  @SideOnly(Side.CLIENT)
+  @Override
+  public boolean hasEffect(ItemStack stack) {
+    return RinguEvent.isActive(stack);
+  }
+
+  @SideOnly(Side.CLIENT)
+  public void initModel() {
+    ModelLoader.setCustomModelResourceLocation(
+        this, 0, new ModelResourceLocation(getRegistryName(), "inventory"));
+  }
+
+  @Override
+  public ActionResult<ItemStack> onItemRightClick(World world, EntityPlayer player, EnumHand hand) {
+    if (!world.isRemote && player.isSneaking()) {
+      RinguEvent.toggleEnabled(player, player.getHeldItem(hand));
     }
+    return super.onItemRightClick(world, player, hand);
+  }
 
-    private static boolean oneRingItemIsActive(ItemStack stack){return RinguNBTUtil.getBoolean(stack, isActive, true);}
-
-    public static boolean oneRingPlayerIsActive(EntityPlayer player){return RinguNBTUtil.getBoolean(player, isActive, false);}
-
-    @SideOnly(Side.CLIENT)
-    @Override
-    public boolean hasEffect(ItemStack stack) {
-        return oneRingItemIsActive(stack);
+  @Override
+  public void addInformation(
+      ItemStack stack, World worldIn, List<String> tooltip, ITooltipFlag flagIn) {
+    if (RinguEvent.isActive(stack)) {
+      tooltip.add(TextFormatting.BLUE + I18n.format("item.ringu.charged"));
+      tooltip.add(TextFormatting.BLUE + I18n.format("item.ringu.activate"));
+    } else {
+      tooltip.add(TextFormatting.BLUE + I18n.format("item.ringu.depleted"));
+      tooltip.add(TextFormatting.BLUE + I18n.format("item.ringu.deactivate"));
     }
-
-    @SideOnly(Side.CLIENT)
-    public void initModel() {
-        ModelLoader.setCustomModelResourceLocation(this, 0, new ModelResourceLocation(getRegistryName(), "inventory"));
-    }
-
-    public static void toggleEnabled(EntityPlayer player, ItemStack stack) {
-        if (oneRingItemIsActive(stack) == oneRingPlayerIsActive(player)){
-            return;
-        }
-        else if(oneRingPlayerIsActive(player)) {
-            RinguEvent.onDeactivation(player);
-        }
-        else{
-            RinguEvent.onActivation(player);
-        }
-         RinguNBTUtil.toggleBoolean(player, isActive, false);
-         RinguNBTUtil.toggleBoolean(stack, isActive, true);
-    }
-
-    @Override
-    public ActionResult<ItemStack> onItemRightClick(World world, EntityPlayer player, EnumHand hand) {
-        ItemStack stack = player.getHeldItem(hand);
-
-        if (player.isSneaking()) {
-            toggleEnabled(player, stack);
-        }
-        return super.onItemRightClick(world, player, hand);
-    }
-
-    @Override
-    public void addInformation(ItemStack stack, World worldIn, List<String> tooltip, ITooltipFlag flagIn){
-        if(oneRingItemIsActive(stack)){
-            tooltip.add(TextFormatting.BLUE + I18n.format("item.ringu.charged"));
-            tooltip.add(TextFormatting.BLUE + I18n.format("item.ringu.activate"));
-        }
-        else{
-            tooltip.add(TextFormatting.BLUE + I18n.format("item.ringu.depleted"));
-            tooltip.add(TextFormatting.BLUE + I18n.format("item.ringu.deactivate"));
-
-        }
-    }
+  }
 }

--- a/src/main/java/com/verch/ringu/proxy/ClientProxy.java
+++ b/src/main/java/com/verch/ringu/proxy/ClientProxy.java
@@ -1,6 +1,5 @@
 package com.verch.ringu.proxy;
 
-
 import com.verch.ringu.RinguItems;
 import net.minecraftforge.client.event.ModelRegistryEvent;
 import net.minecraftforge.fml.common.Mod;
@@ -10,13 +9,13 @@ import net.minecraftforge.fml.relauncher.Side;
 
 @Mod.EventBusSubscriber(Side.CLIENT)
 public class ClientProxy extends CommonProxy {
-    @Override
-    public void preInit(FMLPreInitializationEvent e) {
-        super.preInit(e);
-    }
+  @Override
+  public void preInit(FMLPreInitializationEvent e) {
+    super.preInit(e);
+  }
 
-    @SubscribeEvent
-    public static void registerModels(ModelRegistryEvent event) {
-        RinguItems.initModels();
-    }
+  @SubscribeEvent
+  public static void registerModels(ModelRegistryEvent event) {
+    RinguItems.initModels();
+  }
 }

--- a/src/main/java/com/verch/ringu/proxy/CommonProxy.java
+++ b/src/main/java/com/verch/ringu/proxy/CommonProxy.java
@@ -13,23 +13,19 @@ import net.minecraftforge.fml.common.eventhandler.SubscribeEvent;
 @Mod.EventBusSubscriber
 public class CommonProxy {
 
-    public void preInit(FMLPreInitializationEvent e) {
-    }
+  public void preInit(FMLPreInitializationEvent e) {}
 
-    public void init(FMLInitializationEvent e) {
-    }
+  public void init(FMLInitializationEvent e) {}
 
-    public void postInit(FMLPostInitializationEvent e) {
-    }
+  public void postInit(FMLPostInitializationEvent e) {}
 
-    @SubscribeEvent
-    public static void registerBlocks(RegistryEvent.Register<Block> event) {
-        Registration.registerBlocks(event);
-    }
+  @SubscribeEvent
+  public static void registerBlocks(RegistryEvent.Register<Block> event) {
+    Registration.registerBlocks(event);
+  }
 
-    @SubscribeEvent
-    public static void registerItems(RegistryEvent.Register<Item> event) {
-        Registration.registerItems(event);
-    }
-
+  @SubscribeEvent
+  public static void registerItems(RegistryEvent.Register<Item> event) {
+    Registration.registerItems(event);
+  }
 }

--- a/src/main/java/com/verch/ringu/proxy/ServerProxy.java
+++ b/src/main/java/com/verch/ringu/proxy/ServerProxy.java
@@ -1,4 +1,3 @@
 package com.verch.ringu.proxy;
 
-public class ServerProxy extends CommonProxy {
-}
+public class ServerProxy extends CommonProxy {}

--- a/src/main/java/com/verch/ringu/setup/Registration.java
+++ b/src/main/java/com/verch/ringu/setup/Registration.java
@@ -7,12 +7,11 @@ import net.minecraftforge.event.RegistryEvent;
 
 public class Registration {
 
-    public static void registerBlocks(RegistryEvent.Register<Block> event) {
-    }
+  public static void registerBlocks(RegistryEvent.Register<Block> event) {}
 
-    public static void registerItems(RegistryEvent.Register<Item> event) {
-        RinguItems.init();
-        event.getRegistry().register(RinguItems.itemBaseRing);
-        event.getRegistry().register(RinguItems.itemOneRing);
-    }
+  public static void registerItems(RegistryEvent.Register<Item> event) {
+    RinguItems.init();
+    event.getRegistry().register(RinguItems.itemBaseRing);
+    event.getRegistry().register(RinguItems.itemOneRing);
+  }
 }

--- a/src/main/java/com/verch/ringu/setup/RinguConfig.java
+++ b/src/main/java/com/verch/ringu/setup/RinguConfig.java
@@ -11,141 +11,134 @@ import net.minecraftforge.fml.client.event.ConfigChangedEvent;
 import net.minecraftforge.fml.common.Mod;
 import net.minecraftforge.fml.common.eventhandler.SubscribeEvent;
 
-
 @Config(modid = Ringu.MODID)
 @Mod.EventBusSubscriber(modid = Ringu.MODID)
 public class RinguConfig {
 
-    public static SubCatagoryFlight flight = new SubCatagoryFlight();
-    public static SubCatagoryGround ground = new SubCatagoryGround();
-    public static SubCatagoryWater water = new SubCatagoryWater();
-    public static SubCatagoryFood food = new SubCatagoryFood();
-    public static SubCatagoryMagnet magnet = new SubCatagoryMagnet();
-    public static SubCatagoryEffect effect = new SubCatagoryEffect();
-    public static SubCatagoryCure cure = new SubCatagoryCure();
+  public static SubCatagoryFlight flight = new SubCatagoryFlight();
+  public static SubCatagoryGround ground = new SubCatagoryGround();
+  public static SubCatagoryWater water = new SubCatagoryWater();
+  public static SubCatagoryFood food = new SubCatagoryFood();
+  public static SubCatagoryMagnet magnet = new SubCatagoryMagnet();
+  public static SubCatagoryEffect effect = new SubCatagoryEffect();
+  public static SubCatagoryCure cure = new SubCatagoryCure();
 
-    public static class SubCatagoryFlight {
+  public static class SubCatagoryFlight {
 
-        @Config.Comment("Whether The One Ring enables flight.")
-        public boolean enableFlight = true;
+    @Config.Comment("Whether The One Ring enables flight.")
+    public boolean enableFlight = true;
 
-        @Config.Comment("Flight Speed Multiplier.")
-        @Config.RangeDouble(min = 0.0d, max = 10.0d)
-        public float flySpeedMultiplier = 2.0f;
+    @Config.Comment("Flight Speed Multiplier.")
+    @Config.RangeDouble(min = 0.0d, max = 10.0d)
+    public float flySpeedMultiplier = 2.0f;
+  }
 
-    }
+  public static class SubCatagoryGround {
 
-    public static class SubCatagoryGround {
+    @Config.Comment("Whether The One Ring gives a walk speed buff.")
+    public boolean enableWalkingBuff = true;
 
-        @Config.Comment("Whether The One Ring gives a walk speed buff.")
-        public boolean enableWalkingBuff = true;
+    @Config.Comment("Walk Speed Multiplier.")
+    @Config.RangeDouble(min = 0.0, max = 10.0)
+    public float walkSpeedMultiplier = 2.0f;
+  }
 
-        @Config.Comment("Walk Speed Multiplier.")
-        @Config.RangeDouble(min = 0.0, max = 10.0)
-        public float walkSpeedMultiplier = 2.0f;
+  public static class SubCatagoryWater {
 
-    }
+    @Config.Comment("Whether The One Ring gives water breathing.")
+    public boolean enableWaterBreathing = true;
+  }
 
-    public static class SubCatagoryWater {
+  public static class SubCatagoryFood {
 
-        @Config.Comment("Whether The One Ring gives water breathing.")
-        public boolean enableWaterBreathing = true;
+    @Config.Comment("Whether The One Ring is a source of food.")
+    public boolean enableFood = true;
 
-    }
+    @Config.Comment("Food to add every second.")
+    @Config.RangeInt(min = 0, max = 10)
+    public int foodToAdd = 1;
 
-    public static class SubCatagoryFood {
+    @Config.Comment("Saturation to add every second.")
+    @Config.RangeDouble(min = 0.0, max = 10.0)
+    public float foodSaturationToAdd = 1.0f;
+  }
 
-        @Config.Comment("Whether The One Ring is a source of food.")
-        public boolean enableFood = true;
+  public static class SubCatagoryMagnet {
+    @Config.Comment(
+        "Whether The One Ring acts as an item magnet when activated (Right click when in hand to activate).")
+    public boolean enableMagnet = true;
 
-        @Config.Comment("Food to add every second.")
-        @Config.RangeInt(min = 0, max = 10)
-        public int foodToAdd = 1;
+    @Config.Comment("The range in which the magnet will take effect.")
+    @Config.RangeInt(min = 0, max = 64)
+    public int magnetRange = 16;
+  }
 
-        @Config.Comment("Saturation to add every second.")
-        @Config.RangeDouble(min = 0.0, max = 10.0)
-        public float foodSaturationToAdd = 1.0f;
+  public static class SubCatagoryEffect {
 
-    }
+    @Config.Ignore public BuffEffect[] buffEffectArray;
 
-    public static class SubCatagoryMagnet {
-        @Config.Comment("Whether The One Ring acts as an item magnet when activated (Right click when in hand to activate).")
-        public boolean enableMagnet = true;
-
-        @Config.Comment("The range in which the magnet will take effect.")
-        @Config.RangeInt(min = 0, max = 64)
-        public int magnetRange = 16;
-
-    }
-
-    public static class SubCatagoryEffect {
-
-        @Config.Ignore
-        public BuffEffect[] buffEffectArray;
-
-        @Config.Ignore
-        private static BuffEffect[] buffEffectArrayExample = new BuffEffect[]{
-                new BuffEffect(MobEffects.NIGHT_VISION, 0, 600),
-                new BuffEffect(MobEffects.LUCK, 0, 600)
+    @Config.Ignore
+    private static BuffEffect[] buffEffectArrayExample =
+        new BuffEffect[] {
+          new BuffEffect(MobEffects.NIGHT_VISION, 0, 600), new BuffEffect(MobEffects.LUCK, 0, 600)
         };
 
-        @Config.Comment("Whether The One Ring gives an effect buff.")
-        public boolean enableEffect = true;
+    @Config.Comment("Whether The One Ring gives an effect buff.")
+    public boolean enableEffect = true;
 
-        @Config.Comment("List of Potions to buff with of the form: potion_name,level,duration_in_ticks")
-        public String[] effectArray = BuffEffect.buffEffectArrayToEffectStringArray(buffEffectArrayExample);
+    @Config.Comment("List of Potions to buff with of the form: potion_name,level,duration_in_ticks")
+    public String[] effectArray =
+        BuffEffect.buffEffectArrayToEffectStringArray(buffEffectArrayExample);
 
-        private void init() {
-            buffEffectArray = BuffEffect.BuffEffectListFromEffectStringArray(effectArray);
-        }
+    private void init() {
+      buffEffectArray = BuffEffect.BuffEffectListFromEffectStringArray(effectArray);
     }
+  }
 
-    public static class SubCatagoryCure {
+  public static class SubCatagoryCure {
 
-        @Config.Ignore
-        public Potion[] cureEffectArray;
+    @Config.Ignore public Potion[] cureEffectArray;
 
-        @Config.Ignore
-        private static Potion[] cureEffectArrayExample = new Potion[]{
-                MobEffects.SLOWNESS,
-                MobEffects.MINING_FATIGUE,
-                MobEffects.INSTANT_DAMAGE,
-                MobEffects.NAUSEA,
-                MobEffects.BLINDNESS,
-                MobEffects.HUNGER,
-                MobEffects.WEAKNESS,
-                MobEffects.POISON,
-                MobEffects.WITHER,
-                MobEffects.GLOWING,
-                MobEffects.LEVITATION
+    @Config.Ignore
+    private static Potion[] cureEffectArrayExample =
+        new Potion[] {
+          MobEffects.SLOWNESS,
+          MobEffects.MINING_FATIGUE,
+          MobEffects.INSTANT_DAMAGE,
+          MobEffects.NAUSEA,
+          MobEffects.BLINDNESS,
+          MobEffects.HUNGER,
+          MobEffects.WEAKNESS,
+          MobEffects.POISON,
+          MobEffects.WITHER,
+          MobEffects.GLOWING,
+          MobEffects.LEVITATION
         };
 
-        @Config.Comment("Whether The One Ring cures an effect debuff.")
-        public boolean enableCure = true;
+    @Config.Comment("Whether The One Ring cures an effect debuff.")
+    public boolean enableCure = true;
 
-        @Config.Comment("List of effects to cure")
-        public String[] effectList = EffectUtil.effectArrayToEffectStringArray(cureEffectArrayExample);
+    @Config.Comment("List of effects to cure")
+    public String[] effectList = EffectUtil.effectArrayToEffectStringArray(cureEffectArrayExample);
 
-        private void init() {
-            cureEffectArray = EffectUtil.effectArrayFromEffectStringArray(effectList);
-        }
+    private void init() {
+      cureEffectArray = EffectUtil.effectArrayFromEffectStringArray(effectList);
     }
+  }
 
-    public static void postInit() {
-        effect.init();
-        cure.init();
+  public static void postInit() {
+    effect.init();
+    cure.init();
+  }
+
+  @Mod.EventBusSubscriber(modid = Ringu.MODID)
+  private static class EventHandler {
+
+    @SubscribeEvent
+    public static void onConfigChanged(final ConfigChangedEvent.OnConfigChangedEvent event) {
+      if (event.getModID().equals(Ringu.MODID)) {
+        ConfigManager.sync(Ringu.MODID, Config.Type.INSTANCE);
+      }
     }
-
-    @Mod.EventBusSubscriber(modid = Ringu.MODID)
-    private static class EventHandler {
-
-        @SubscribeEvent
-        public static void onConfigChanged(final ConfigChangedEvent.OnConfigChangedEvent event) {
-            if (event.getModID().equals(Ringu.MODID)) {
-                ConfigManager.sync(Ringu.MODID, Config.Type.INSTANCE);
-            }
-        }
-    }
-
+  }
 }
-

--- a/src/main/java/com/verch/ringu/setup/RinguCreativeTab.java
+++ b/src/main/java/com/verch/ringu/setup/RinguCreativeTab.java
@@ -6,14 +6,12 @@ import net.minecraft.item.ItemStack;
 
 public class RinguCreativeTab extends CreativeTabs {
 
-    public RinguCreativeTab(String label) {
-        super(label);
-    }
+  public RinguCreativeTab(String label) {
+    super(label);
+  }
 
-    @Override
-    public ItemStack getTabIconItem() {
-        return new ItemStack(RinguItems.itemOneRing);
-    }
-
-
+  @Override
+  public ItemStack getTabIconItem() {
+    return new ItemStack(RinguItems.itemOneRing);
+  }
 }

--- a/src/main/java/com/verch/ringu/util/RinguNBTUtil.java
+++ b/src/main/java/com/verch/ringu/util/RinguNBTUtil.java
@@ -6,37 +6,36 @@ import net.minecraft.nbt.NBTTagCompound;
 
 public class RinguNBTUtil {
 
-
-    private static NBTTagCompound getOrCreateCompound(ItemStack stack){
-        NBTTagCompound compound = stack.getTagCompound();
-        if(compound == null){
-            compound = new NBTTagCompound();
-            stack.setTagCompound(compound);
-        }
-        return compound;
+  private static NBTTagCompound getOrCreateCompound(ItemStack stack) {
+    NBTTagCompound compound = stack.getTagCompound();
+    if (compound == null) {
+      compound = new NBTTagCompound();
+      stack.setTagCompound(compound);
     }
+    return compound;
+  }
 
-    private static boolean getBoolean(NBTTagCompound compound, String tag, boolean defaultExpected) {
-        return compound.hasKey(tag) ? compound.getBoolean(tag) : defaultExpected;
-    }
+  private static boolean getBoolean(NBTTagCompound compound, String tag, boolean defaultExpected) {
+    return compound.hasKey(tag) ? compound.getBoolean(tag) : defaultExpected;
+  }
 
-    private static void toggleBoolean(NBTTagCompound compound, String tag, boolean defaultExpected) {
-        compound.setBoolean(tag, !getBoolean(compound, tag, defaultExpected));
-    }
+  private static void toggleBoolean(NBTTagCompound compound, String tag, boolean defaultExpected) {
+    compound.setBoolean(tag, !getBoolean(compound, tag, defaultExpected));
+  }
 
-    public static void toggleBoolean(EntityPlayer player, String tag, boolean defaultExpected) {
-        toggleBoolean(player.getEntityData(), tag, defaultExpected);
-    }
+  public static void toggleBoolean(EntityPlayer player, String tag, boolean defaultExpected) {
+    toggleBoolean(player.getEntityData(), tag, defaultExpected);
+  }
 
-    public static void toggleBoolean(ItemStack stack, String tag, boolean defaultExpected) {
-        toggleBoolean(getOrCreateCompound(stack), tag, defaultExpected);
-    }
+  public static void toggleBoolean(ItemStack stack, String tag, boolean defaultExpected) {
+    toggleBoolean(getOrCreateCompound(stack), tag, defaultExpected);
+  }
 
-    public static boolean getBoolean(EntityPlayer player, String tag, boolean defaultExpected) {
-        return getBoolean(player.getEntityData(), tag, defaultExpected);
-    }
+  public static boolean getBoolean(EntityPlayer player, String tag, boolean defaultExpected) {
+    return getBoolean(player.getEntityData(), tag, defaultExpected);
+  }
 
-    public static boolean getBoolean(ItemStack stack, String tag, boolean defaultExpected) {
-        return getBoolean(getOrCreateCompound(stack), tag, defaultExpected);
-    }
+  public static boolean getBoolean(ItemStack stack, String tag, boolean defaultExpected) {
+    return getBoolean(getOrCreateCompound(stack), tag, defaultExpected);
+  }
 }

--- a/src/main/resources/assets/ringu/lang/en_us.lang
+++ b/src/main/resources/assets/ringu/lang/en_us.lang
@@ -1,6 +1,6 @@
 #PARSE_ESCAPES
 
-item.ringu.basering.name=The Base Ringo
+item.ringu.basering.name=The Base Ring
 item.ringu.onering.name=The One Ring
 
 itemGroup.Ringu=Ringu

--- a/src/main/resources/pack.mcmeta
+++ b/src/main/resources/pack.mcmeta
@@ -1,0 +1,6 @@
+{
+  "pack": {
+    "pack_format": 3,
+    "description": "Resources used for Ringu"
+  }
+}


### PR DESCRIPTION
Fix for localisation and creative flight bug.

Localisation is fixed by adding a pack.mcmeta file to the resource
folder.

Creative flight bug occurs when having the ring buff enabled, going
into creative and then survival. The change from creative to survival
removes the flight buff. To get around this activating a charged one
ring while already buffed will reenable flight without removing the
charge.

To help remove the buff from a player entirely an option has been added
to the base ring. Sneek right clicking will permanently remove the
buff.

In addition code relating to the activiation via right clicking was
moved from the one ring to the event package. This allows for better
sharing for the new behaviour of the base ring and keeps the logic of
activating and deactivating the buff in one place.